### PR TITLE
Update packages and add missing Windows package

### DIFF
--- a/CompletedSolution/Consumer/tests/tests.csproj
+++ b/CompletedSolution/Consumer/tests/tests.csproj
@@ -13,6 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="PactNet.OSX" Version="2.2.1" />
+    <PackageReference Include="PactNet.Windows" Version="2.2.1" />
+    <PackageReference Include="PactNet.Linux.x86" Version="2.2.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/CompletedSolution/Provider/src/Controllers/ProviderController.cs
+++ b/CompletedSolution/Provider/src/Controllers/ProviderController.cs
@@ -38,7 +38,7 @@ namespace Provider.Controllers
             {
                 parsedDateTime = DateTime.Parse(validDateTime);
             }
-            catch(Exception ex)
+            catch(Exception)
             {
                 return BadRequest(new { message = "validDateTime is not a date or time" });
             }

--- a/CompletedSolution/Provider/src/provider.csproj
+++ b/CompletedSolution/Provider/src/provider.csproj
@@ -9,11 +9,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
   </ItemGroup>
 
   <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.1" />
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.2" />
   </ItemGroup>
 
 </Project>

--- a/CompletedSolution/Provider/tests/tests.csproj
+++ b/CompletedSolution/Provider/tests/tests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="PactNet.OSX" Version="2.2.1" />
     <PackageReference Include="PactNet.Windows" Version="2.2.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
   </ItemGroup>
 
 </Project>

--- a/CompletedSolution/Provider/tests/tests.csproj
+++ b/CompletedSolution/Provider/tests/tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="PactNet.OSX" Version="2.2.1" />
     <PackageReference Include="PactNet.Windows" Version="2.2.1" />
+    <PackageReference Include="PactNet.Linux.x86" Version="2.2.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />

--- a/CompletedSolution/Provider/tests/tests.csproj
+++ b/CompletedSolution/Provider/tests/tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="PactNet.OSX" Version="2.2.1" />
+    <PackageReference Include="PactNet.Windows" Version="2.2.1" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />


### PR DESCRIPTION
  1. Add missing package to run the consumer tests on Windows.
  1. Update the various packages to their latest versions.
  1. Fixed a compiler warning.